### PR TITLE
fix: 调整了一处dialog样式问题

### DIFF
--- a/src/main/resources/scss/base.scss
+++ b/src/main/resources/scss/base.scss
@@ -779,7 +779,7 @@ a[class*=" icon-"]:hover {
 }
 
 .dialog-main {
-  min-width: 500px;
+  min-width: 480px;
   padding: 10px;
   box-sizing: content-box;
 }


### PR DESCRIPTION

padding左右10，会导致实际宽度变为520，右侧不够用。
所以最小宽调整为480，配合padding后宽度变为500。

虽也可调整box-sizing，但未评估对其他dialog的影响，所以选择了减宽度。

![image](https://user-images.githubusercontent.com/16379552/162354812-fdc91386-bfdb-47ac-90a3-04f22d096a68.png)


![image](https://user-images.githubusercontent.com/16379552/162354352-2d6e91ec-bf3c-42e4-bfd8-16cdc86524d2.png)
